### PR TITLE
Update idpool.py

### DIFF
--- a/scripts/idpool.py
+++ b/scripts/idpool.py
@@ -1,22 +1,86 @@
-from itertools import count, filterfalse
+from itertools import count
+from threading import Lock
 
 class IDPool(set):
-    def __init__(self, protocol):
-        self.protocol = protocol
+    """
+    A thread-safe ID pool manager that allocates and deallocates unique IDs with advanced features.
+    
+    Args:
+        start (int): The starting ID value (default: 0).
+        step (int): The increment step between IDs (default: 1).
+        max_id (int, optional): The maximum allowable ID; if exceeded, raises an error.
+        reserved (iterable, optional): IDs that are reserved and cannot be allocated.
+        logger (logging.Logger, optional): Logger instance for tracking ID operations.
+    """
+    def __init__(self, start=0, step=1, max_id=None, reserved=None, logger=None):
+        self.start = start
+        self.step = step
+        self.max_id = max_id
+        self.reserved = set(reserved) if reserved else set()
+        self.logger = logger
+        self.lock = Lock()  # Ensures thread-safe operations
         super().__init__()
 
     def pop(self):
-        ID = next(filterfalse(self.__contains__, count()))
-        self.add(ID)
-        return ID
+        """
+        Allocates and returns the next available ID that is neither in use nor reserved.
+        
+        Returns:
+            int: The allocated ID.
+            
+        Raises:
+            ValueError: If no IDs are available within the specified range.
+        """
+        with self.lock:
+            # Generator expression to find the next available ID
+            ID = next(ID for ID in count(self.start, self.step) 
+                     if ID not in self and ID not in self.reserved)
+            if self.max_id is not None and ID > self.max_id:
+                raise ValueError("No more IDs available within the specified range")
+            self.add(ID)
+            if self.logger:
+                self.logger.debug(f"Allocated ID: {ID}")
+            return ID
 
     def put_back(self, ID):
-        self.remove(ID)
+        """
+        Deallocates an ID, making it available for reuse.
+        
+        Args:
+            ID: The ID to return to the pool.
+        """
+        with self.lock:
+            if ID not in self:
+                if self.logger:
+                    self.logger.warning(f"Attempt to put back non-allocated ID: {ID}")
+                return  # Silently ignore if ID wasn't allocated
+            self.remove(ID)
+            if self.logger:
+                self.logger.debug(f"Deallocated ID: {ID}")
 
 def apply_script(protocol, connection, config):
+    """
+    Extends a protocol with an enhanced IDPool instance, configurable via the config parameter.
+    
+    Args:
+        protocol: The base protocol class to extend.
+        connection: The connection object (passed through unchanged).
+        config (dict): Configuration dictionary, with optional 'id_pool' key for IDPool settings.
+        
+    Returns:
+        tuple: (Enhanced protocol class, connection)
+    """
     class IDPoolProtocol(protocol):
-        def __init__(self, *w, **kw):
-            protocol.__init__(self, *w, **kw)
-            self.player_ids = IDPool(self)
+        def __init__(self, *args, **kwargs):
+            protocol.__init__(self, *args, **kwargs)
+            # Extract ID pool configuration from config, if provided
+            id_pool_config = config.get('id_pool', {})
+            self.player_ids = IDPool(
+                start=id_pool_config.get('start', 0),
+                step=id_pool_config.get('step', 1),
+                max_id=id_pool_config.get('max_id'),
+                reserved=id_pool_config.get('reserved'),
+                logger=getattr(self, 'logger', None)  # Use protocol's logger if available
+            )
 
     return IDPoolProtocol, connection


### PR DESCRIPTION
Thread Safety
Added a threading.Lock to ensure that pop and put_back operations are atomic, preventing race conditions in multi-threaded environments.

Configurable ID Generation
Start and Step: IDs now start at a configurable start value (default 0) and increment by a configurable step (default 1). For example, start=1000, step=2 generates IDs 1000, 1002, 1004, etc.

Maximum ID: An optional max_id parameter limits the range of IDs. If the next available ID exceeds max_id, a ValueError is raised.

Reserved IDs
Added a reserved set to specify IDs that cannot be allocated, useful for reserving special-purpose IDs.

Logging Support
Integrated optional logging via a logger parameter. When provided, it logs ID allocations and deallocations at the DEBUG level, and warns about attempts to deallocate unallocated IDs at the WARNING level.

Improved Error Handling
The put_back method now checks if the ID is actually in the pool before attempting removal, preventing KeyError exceptions and optionally logging a warning.

The pop method raises a ValueError if no IDs are available within the specified range (when max_id is set).

Decoupled from Protocol
Removed the mandatory protocol parameter from IDPool, making it a standalone class that can be used independently or configured via the protocol's config.